### PR TITLE
add sanity check to the resolver

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -227,6 +227,9 @@ const getType = (propertyConfig, required, property, ctdName) => {
                 resolve: async (source, args, context, info) => {
                     if (source[property]) {
                         let nodes = await Promise.all(source[property].map(async (prop) => {
+                            if(typeof(prop.dataUrl) === 'undefined'){
+                                    return;
+                            }
                             let node = {
                                 id: typeNonCapitalize === '_media' ?
                                     prop.dataUrl.split('/')[5] : typeNonCapitalize + '_' + prop.dataUrl.split('/')[5],


### PR DESCRIPTION
Do not further resolve nodes that are not data sources as it may lead to GQL errors further down the line.

```
{
  "errors": [
    {
      "message": "Cannot read property 'split' of undefined",
      "locations": [
        {
          "line": 24,
          "column": 11
        }
      ],
      "path": [
        "allFlotiqBlogPost",
        "edges",
        0,
        "node",
        "tags"
      ],
      "stack": [
        "TypeError: Cannot read property 'split' of undefined",
        "    at Promise.all.source.(anonymous function).map (/home/andrzej/dev/flotiq-blog-worker/flotiq-blog/node_modules/gatsby-source-flotiq/gatsby-node.js:235:106)",
        "    at Array.map (<anonymous>)",
        "    at resolve (/home/andrzej/dev/flotiq-blog-worker/flotiq-blog/node_modules/gatsby-source-flotiq/gatsby-node.js:229:72)",
        "    at resolveFieldValueOrError (/home/andrzej/dev/flotiq-blog-worker/flotiq-blog/node_modules/graphql/execution/execute.js:503:18)",
        "    at resolveField (/home/andrzej/dev/flotiq-blog-worker/flotiq-blog/node_modules/graphql/execution/execute.js:470:16)",
        "    at executeFields (/home/andrzej/dev/flotiq-blog-worker/flotiq-blog/node_modules/graphql/execution/execute.js:311:18)",
        "    at collectAndExecuteSubfields (/home/andrzej/dev/flotiq-blog-worker/flotiq-blog/node_modules/graphql/execution/execute.js:747:10)",
        "    at completeObjectValue (/home/andrzej/dev/flotiq-blog-worker/flotiq-blog/node_modules/graphql/execution/execute.js:737:10)",
        "    at completeValue (/home/andrzej/dev/flotiq-blog-worker/flotiq-blog/node_modules/graphql/execution/execute.js:626:12)",
        "    at completeValue (/home/andrzej/dev/flotiq-blog-worker/flotiq-blog/node_modules/graphql/execution/execute.js:593:21)",
        "    at completeValueCatchingError (/home/andrzej/dev/flotiq-blog-worker/flotiq-blog/node_modules/graphql/execution/execute.js:531:19)",
        "    at resolveField (/home/andrzej/dev/flotiq-blog-worker/flotiq-blog/node_modules/graphql/execution/execute.js:471:10)",
        "    at executeFields (/home/andrzej/dev/flotiq-blog-worker/flotiq-blog/node_modules/graphql/execution/execute.js:311:18)",
        "    at collectAndExecuteSubfields (/home/andrzej/dev/flotiq-blog-worker/flotiq-blog/node_modules/graphql/execution/execute.js:747:10)",
        "    at completeObjectValue (/home/andrzej/dev/flotiq-blog-worker/flotiq-blog/node_modules/graphql/execution/execute.js:737:10)",
        "    at completeValue (/home/andrzej/dev/flotiq-blog-worker/flotiq-blog/node_modules/graphql/execution/execute.js:626:12)"
      ]
    },
```