### PR TITLE
Data loading reafactor and improved fetch parallelism

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ module.exports = {
             authToken: process.env.GATSBY_FLOTIQ_API_KEY,
             forceReload: false, //(optional)
             includeTypes: ['contettype1', 'contettype2', ... ], //(optional) List of used contenttypes identified by API Name. If ommitted, all content types will be synchronized. Make sure to include all referenced content types as well
-            objectLimit: 100000, //optional, limit number of objects for every type
+            objectLimit: 100000, //optional, limit total number of objects downloaded for every type
+            singleFetchLimit: 1000, //optional, limit the number of objects downloaded in single api call. Min: 1, Max 5000, Default 1000
+            maxConcurrentDataDownloads: 10, //optional, limit the number of concurrent api calls. Default: 10, Min: 1, Max: 50
             timeout: 5000, //optional
             resolveMissingRelations: true, //optional, if the limit of objects is small some of the objects in relations could not be obtained from server, it this option is true they will be obtained as the graphQL queries in project would be resolved, if false, the missing object would resolve to null
             downloadMediaFile: false //optional, should media files be cached and be available for gatsby-image and gatsby-sharp
@@ -63,7 +65,9 @@ module.exports = {
 * `authToke` - API token, if you wish to only pull data from Flotiq it can be Red-only key, if you need to put data it has to be Read-write key, more about Flotiq API keys [here](https://flotiq.com/docs/API/)
 * `forceRelaod` - indicates if the data should be pulled in full or plugin should use cache (`true` for full pull, `false` for cache usage)
 * `includeTypes` - array of Content Type Definitions used in the project (if you use images or files pulled from Flotiq, you must include `_media` CTD)
-* `objectsLimit` - if you wish to not pull all objects from Flotiq (e.g. in development to speed up reload), you can limit it using this parameter, in production it should be higher than number of object in any Content Type pulled to project
+* `objectsLimit` - if you wish to not pull all objects from Flotiq (e.g. in development to speed up reload), you can limit it using this parameter. This will limit the total number of downloaded objects. In production it should be higher than number of object in any Content Type pulled to project
+* `singleFetchLimit` - if you experience timeuts, or any other problems with download, you can change the default number of objects downloaded in a single API call. It has to be in integer from `1` to `5000`. The default value is `1000`.
+* `maxConcurrentDataDownloads` - If you have a large number of content types, or many objects in a single content type, you can change the default number of concurrent connections. It has to be in integer from `1` to `50`. The default value is `10`.
 * `timeout` - time (in milliseconds) after which connection to Flotiq should timed out
 * `resolveMissingRelations` - when the `objectsLimit` is smaller than number of objects in CTDs to avoid nulls on objects connected to other objects plugin make additional calls to pull missing data, if you want to suppress this behavior set this parameter to `false` 
 * `downloadMediaFile` - should media files be downloaded and cached and be available fully for gatsby-image and gatsby-image-sharp

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,11 +1,10 @@
 const fetch = require('node-fetch');
 const {createContentDigest} = require(`gatsby-core-utils`);
+const {getContentTypes, getDeletedObjects, getContentObjects} = require('./src/data-loader');
+const {capitalize} = require('./src/utils')
 
 const digest = str => createContentDigest(str);
 
-let headers = {
-    'accept': 'application/json',
-};
 let apiUrl;
 
 let typeDefinitionsDeferred;
@@ -25,18 +24,16 @@ exports.sourceNodes = async (gatsbyFunctions, options) => {
         baseUrl,
         authToken,
         forceReload,
-        objectLimit = 100000,
-        timeout = 5000,
         includeTypes = null,
         resolveMissingRelations = true,
         downloadMediaFile = false
     } = options;
-
+    
     createNodeGlobal = createNode;
     resolveMissingRelationsGlobal = resolveMissingRelations;
     downloadMediaFileGlobal = downloadMediaFile;
     apiUrl = baseUrl;
-    headers['X-AUTH-TOKEN'] = authToken;
+    
     if (!apiUrl) {
         reporter.panic('FLOTIQ: You must specify API url ' +
             '(in most cases it is "https://api.flotiq.com")');
@@ -49,22 +46,12 @@ exports.sourceNodes = async (gatsbyFunctions, options) => {
     if (includeTypes && (!Array.isArray(includeTypes) || typeof includeTypes[0] !== "string")) {
         reporter.panic("FLOTIQ: `includeTypes` should be an array of content type api names. It cannot be empty.");
     }
-
-    let contentTypeDefinitionsResponse = await fetch(
-        apiUrl + '/api/v1/internal/contenttype?limit=10000&order_by=label',
-        {
-            headers: headers,
-            timeout: timeout
-        });
-
-    if (contentTypeDefinitionsResponse.ok) {
+    try {
         if (forceReload) {
             setPluginStatus({'updated_at': null});
         }
         let lastUpdate = store.getState().status.plugins['gatsby-source-flotiq'];
-        let contentTypeDefinitions = await contentTypeDefinitionsResponse.json();
-        const contentTypeDefsData = contentTypeDefinitions.data.filter(
-            contentTypeDef => !includeTypes || includeTypes.indexOf(contentTypeDef.name) > -1);
+        
         const existingNodes = getNodes().filter(
             n => n.internal.owner === `gatsby-source-flotiq`
         );
@@ -72,60 +59,36 @@ exports.sourceNodes = async (gatsbyFunctions, options) => {
         if (!existingNodes.length) {
             lastUpdate = undefined;
         }
+
+        const contentTypeDefsData = await getContentTypes(options);
         createTypeDefs(contentTypeDefsData, schema);
 
         let changed = 0;
         let removed = 0;
-        await Promise.all(contentTypeDefsData.map(async ctd => {
-            let url = apiUrl + '/api/v1/content/' + ctd.name + '?limit=' + objectLimit;
+        
+        if (lastUpdate && lastUpdate.updated_at) {
+            removed = await getDeletedObjects(gatsbyFunctions, options, lastUpdate.updated_at, contentTypeDefsData, async (ctd, id) => {
+                let node = existingNodes.find(n => n.id === ctd.name + '_' + id);
+                return await deleteNode({node});
+            });
+        }
 
-            if (lastUpdate && lastUpdate.updated_at) {
-                url += '&filters=' + encodeURIComponent(JSON.stringify({
-                    "internal.updatedAt": {
-                        "type": "greaterThan",
-                        "filter": lastUpdate.updated_at
-                    }
-                }))
-            }
-            let response = await fetch(url, {headers: headers, timeout: timeout});
-            reporter.info(`Fetching content type ${ctd.name}: ${url}`);
-
-            if (response.ok) {
-                const json = await response.json();
-                await Promise.all(json.data.map(async datum => {
-                    changed++;
-                    return createNode({
-                        ...datum,
-                        // custom
-                        flotiqInternal: datum.internal,
-                        // required
-                        id: ctd.name === '_media' ? datum.id : ctd.name + '_' + datum.id,
-                        parent: null,
-                        children: [],
-                        internal: {
-                            type: capitalize(ctd.name),
-                            contentDigest: digest(JSON.stringify(datum)),
-                        },
-                    });
-
-                }));
-            } else {
-                reporter.warn('Error fetching data', response);
-            }
-            if (lastUpdate && lastUpdate.updated_at) {
-                url = apiUrl + '/api/v1/content/' + ctd.name + '/removed?deletedAfter=' + encodeURIComponent(lastUpdate.updated_at);
-                response = await fetch(url, {headers: headers});
-                reporter.info(`Fetching removed content type ${ctd.name}: ${url}`);
-                if (response.ok) {
-                    const jsonRemoved = await response.json();
-                    await Promise.all(jsonRemoved.map(async id => {
-                        removed++;
-                        let node = existingNodes.find(n => n.id === ctd.name + '_' + id);
-                        return deleteNode({node: node});
-                    }));
-                }
-            }
-        }));
+        changed = await getContentObjects(gatsbyFunctions, options, lastUpdate && lastUpdate.updated_at, contentTypeDefsData, async (ctd, datum) => {
+            return createNode({
+                ...datum,
+                // custom
+                flotiqInternal: datum.internal,
+                // required
+                id: ctd.name === '_media' ? datum.id : ctd.name + '_' + datum.id,
+                parent: null,
+                children: [],
+                internal: {
+                    type: capitalize(ctd.name),
+                    contentDigest: digest(JSON.stringify(datum)),
+                },
+            });
+        })
+        
         if (changed) {
             reporter.info('Updated entries ' + changed);
         }
@@ -136,16 +99,10 @@ exports.sourceNodes = async (gatsbyFunctions, options) => {
             'updated_at':
                 (new Date()).toISOString().replace(/T/, ' ').replace(/\..+/, '')
         });
-    } else {
-        if (contentTypeDefinitionsResponse.status === 404) {
-            reporter.panic('FLOTIQ: We couldn\'t connect to API. Check if you specified correct API url ' +
-                '(in most cases it is "https://api.flotiq.com")');
-        }
-        if (contentTypeDefinitionsResponse.status === 403) {
-            reporter.panic('FLOTIQ: We couldn\'t authorize you in API. Check if you specified correct API token ' +
-                '(if you don\'t know what it is check: https://flotiq.com/docs/API/)');
-        }
+    } catch(e) {
+        reporter.panic('FLOTIQ: ' + e.message)
     }
+
     return {};
 };
 
@@ -372,10 +329,7 @@ const createSrcSetFixed = (apiUrl, source, args) => {
     return array.join(',\n')
 }
 
-const capitalize = (s) => {
-    if (typeof s !== 'string') return '';
-    return s.charAt(0).toUpperCase() + s.slice(1);
-};
+
 
 const getType = (propertyConfig, required, property, ctdName) => {
     switch (propertyConfig.inputType) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "gatsby-source-flotiq",
-    "version": "2.0.4",
+    "version": "2.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gatsby-source-flotiq",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "keywords": [
         "flotiq",
         "gatsby",

--- a/src/data-loader.js
+++ b/src/data-loader.js
@@ -62,15 +62,17 @@ module.exports.getContentObjects = async function (gatsbyFunctions, options, sin
     const {
         baseUrl,
         objectLimit = 100000,
-        timeout = 5000,
-        maxConcurrentDataDownloads = 10
+        timeout = 5000
     } = options;
     
     let {
-        singleFetchLimit = 1000
+        singleFetchLimit = 1000,
+        maxConcurrentDataDownloads = 10
     } = options;
     
-    singleFetchLimit = Math.min(singleFetchLimit, 5000); //We're hard capping single fetch, limit
+    maxConcurrentDataDownloads = Math.max(Math.min(maxConcurrentDataDownloads, 50), 1)  // 1 <= maxConcurrentDataDownloads  <= 50
+    singleFetchLimit = Math.max(Math.min(singleFetchLimit, 5000), 1);                   // 1 <= singleFetchLimit            <= 5000
+
     let changed = 0;
     let downloadJobs = contentTypes.map(ctd => {
         let currentNodeCount = 0;

--- a/src/data-loader.js
+++ b/src/data-loader.js
@@ -67,7 +67,7 @@ module.exports.getContentObjects = async function (gatsbyFunctions, options, sin
     } = options;
     
     let {
-        singleFetchLimit = 5000
+        singleFetchLimit = 1000
     } = options;
     
     singleFetchLimit = Math.min(singleFetchLimit, 5000); //We're hard capping single fetch, limit

--- a/src/data-loader.js
+++ b/src/data-loader.js
@@ -1,0 +1,134 @@
+const fetch = require('node-fetch');
+const workers = require('./workers')
+const {capitalize, createHeaders} = require('./utils')
+
+module.exports.getContentTypes = async function (options) {
+    const {
+        timeout = 5000,
+        includeTypes = null,
+        baseUrl
+    } = options;
+
+    let contentTypeDefinitionsResponse = await fetch(
+        baseUrl + '/api/v1/internal/contenttype?limit=10000&order_by=label',
+        {
+            headers: createHeaders(options),
+            timeout: timeout
+        });
+    
+    if (contentTypeDefinitionsResponse.ok) {
+        let contentTypeDefinitions = await contentTypeDefinitionsResponse.json();
+        const contentTypeDefsData = contentTypeDefinitions.data.filter(
+            contentTypeDef => !includeTypes || includeTypes.indexOf(contentTypeDef.name) > -1);
+
+        return contentTypeDefsData
+    } else {
+        if (contentTypeDefinitionsResponse.status === 404) {
+            throw new Error(`We couldn't connect to API. Check if you specified correct API url (in most cases it is "https://api.flotiq.com")`)
+        } else if (contentTypeDefinitionsResponse.status === 403) {
+            throw new Error(`We couldn't authorize you in API. Check if you specified correct API token (if you don't know what it is check: https://flotiq.com/docs/API/)`)
+        } else throw new Error(await contentTypeDefinitionsResponse.text())
+        
+    }
+} 
+
+module.exports.getDeletedObjects = async function (gatsbyFunctions, options, since, contentTypes, handleDeletedId) {
+    let removed = 0;
+    const { reporter } = gatsbyFunctions;
+    const {
+        baseUrl
+    } = options;
+    await Promise.all(contentTypes.map(async ctd => {
+        
+        let url = baseUrl + '/api/v1/content/' + ctd.name + '/removed?deletedAfter=' + encodeURIComponent(since);
+        response = await fetch(url, {headers: createHeaders(options)});
+        reporter.info(`Fetching removed content type ${ctd.name}: ${url}`);
+        if (response.ok) {
+            const jsonRemoved = await response.json();
+            await Promise.all(jsonRemoved.map(async id => {
+                removed++;
+                return await handleDeletedId(ctd, id)
+            }));
+        }
+        
+    }));
+
+    return removed;
+}
+
+module.exports.getContentObjects = async function (gatsbyFunctions, options, since, contentTypes, handleObject) {
+    const { reporter, getNodesByType } = gatsbyFunctions;
+
+    const {
+        baseUrl,
+        objectLimit = 100000,
+        timeout = 5000,
+        maxConcurrentDataDownloads = 10
+    } = options;
+    
+    let {
+        singleFetchLimit = 5000
+    } = options;
+    
+    singleFetchLimit = Math.min(singleFetchLimit, 5000); //We're hard capping single fetch, limit
+    let changed = 0;
+    let downloadJobs = contentTypes.map(ctd => {
+        let currentNodeCount = 0;
+        let limitPerPage = Math.min(singleFetchLimit, objectLimit);
+        let url = baseUrl + '/api/v1/content/' + ctd.name + '?limit=' + limitPerPage + '';
+
+        if (since) {
+            currentNodeCount = getNodesByType(capitalize(ctd.name)).count;
+            url += '&filters=' + encodeURIComponent(JSON.stringify({
+                "internal.updatedAt": {
+                    "type": "greaterThan",
+                    "filter": since
+                }
+            }))
+        }
+        
+        return {
+            baseUrl: url,
+            objectLimit: objectLimit - currentNodeCount,
+            limitPerPage,
+            page: 1,
+            ctd
+        }
+    });
+
+    const dataLoadCount = {}
+
+    await workers(downloadJobs, maxConcurrentDataDownloads, async ({baseUrl, objectLimit, page, ctd, totalPages, limitPerPage}) => {
+        const url = `${baseUrl}&page=${page}`;
+        const humanizedPageNumber = page === 1 ? 'frist page' : `${page}/${totalPages}`
+        reporter.info(`Fetching${since ? ' updates' : ''}: ${ctd.name} ${humanizedPageNumber}`)
+        let response = await fetch(url, {headers: createHeaders(options), timeout: timeout});
+        if (!response.ok) 
+        {
+            reporter.warn('Error fetching data', response);
+            return;
+        }
+
+        const json = await response.json();
+        totalPages = json.total_pages;
+        dataLoadCount[ctd.name] = dataLoadCount[ctd.name] || 0; 
+        await Promise.all(json.data.map(async datum => {
+            changed++;
+            dataLoadCount[ctd.name]++;
+            return await handleObject(ctd, datum)
+        }));
+
+        // Now that we know the dataset size, we can try to queue the rest of the download
+        if(page === 1 && json.total_pages > page) {
+            let maxAllowedPages = Math.ceil(objectLimit/limitPerPage);
+            let pageLimit = Math.min(json.total_pages, maxAllowedPages);
+            for(let i = page + 1; i <= pageLimit; i++) {
+              downloadJobs.push({
+                baseUrl, objectLimit, page: i, ctd, totalPages: pageLimit
+              }) 
+            }
+        }
+    })
+
+    return changed;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,17 @@
+module.exports.capitalize = (s) => {
+    if (typeof s !== 'string') return '';
+    return s.charAt(0).toUpperCase() + s.slice(1);
+};
+
+module.exports.createHeaders = (options) => {
+    const {
+        authToken
+    } = options;
+
+    
+    let headers = {
+        'accept': 'application/json',
+        'X-AUTH-TOKEN': authToken
+    };
+    return headers;
+};

--- a/src/workers.js
+++ b/src/workers.js
@@ -1,0 +1,18 @@
+/**
+ * 
+ * @param {Array} input 
+ * @param {int} workerLimit 
+ * @param {function} taskFN 
+ */
+module.exports = async function workers(input, workerLimit = 10, taskFN) {
+  let workerIndices = [... (new Array(workerLimit)).keys()]; // an array of 0,1,..,workerLimit - 1
+  let results = [];
+  currentDataIdx = 0;
+  await Promise.all(workerIndices.map(async function(n){
+      while (input.length) {
+        let localDataIdx = currentDataIdx++;
+        results[localDataIdx] = await taskFN(input.shift());
+      }
+  }));
+  return results;
+}


### PR DESCRIPTION
### Rationale

Because we are often using the plugin with large datasets (over 20 000), I thought it mandatory to have a proper download job management and download limits. 

### Please, help with testing
It goes without saying, that the PR touches on crucial parts of the plugin. I'd feel better if someone else gave it a go and test it in different projects. I tested most of the basic functions (data loading, data loading with cache filled, data removal and updates), but I am sure I missed some things.

### Functional improvements

- `singleFetchLimit` - an option, which forces data download in chunks. default: `1000`, max `5000`
- `maxConcurrentDataDownloads` - an option which limits the number of concurrent downloads. Default: `10`

Please review those default values - I think we might want to reduce them further

### Engine improvements

- The data now is downloaded by workers, using a simple download queue. The queue is populated first when downloading one page from each Content Type, and then (once we know the number of objects to be downloaded), the rest of the jobs is being filled into the queue


### Refactoring

This was a good opportunity to start splitting the code by responsibility as I had to rewrite the data loading anyway, so:
- Data loading methods (content types, content objects, content object removals) are extracted into `src/data-loader.js`. Currently, they are gatsby-aware to be able to check the number of nodes in each content type etc. However, these are not registering new nodes, nor removing them - I kept that intentionally outside. 
- Some utility functions were extracted into `src/utils.js` - mostly for the sake of re-usage in `data-loader.js`
- Workers mini-library was created in `src/workers.js`

The refactoring process is not finished in my opinion, but I didn't want to move everything at once, so I stopped at the level I felt manageable in single PR. 