### PR TITLE
add default api url

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -22,7 +22,7 @@ exports.sourceNodes = async (gatsbyFunctions, options) => {
     const {actions, store, getNodes, reporter, schema} = gatsbyFunctions;
     const {createNode, setPluginStatus, touchNode, deleteNode} = actions;
     const {
-        baseUrl,
+        baseUrl = "https://api.flotiq.com",
         authToken,
         forceReload,
         objectLimit = 100000,
@@ -37,10 +37,6 @@ exports.sourceNodes = async (gatsbyFunctions, options) => {
     downloadMediaFileGlobal = downloadMediaFile;
     apiUrl = baseUrl;
     headers['X-AUTH-TOKEN'] = authToken;
-    if (!apiUrl) {
-        reporter.panic('FLOTIQ: You must specify API url ' +
-            '(in most cases it is "https://api.flotiq.com")');
-    }
     if (!authToken) {
         reporter.panic("FLOTIQ: You must specify API token " +
             "(if you don't know what it is check: https://flotiq.com/docs/API/)");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gatsby-source-flotiq",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "keywords": [
         "flotiq",
         "gatsby",


### PR DESCRIPTION
Because only enterprise users and Flotiq developers use other base url than `https://api.flotiq.com` I've added this as a default value. It should simplify about 99% of the projects. 