### PR TITLE
Fix deprecated code

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -70,7 +70,7 @@ exports.sourceNodes = async (gatsbyFunctions, options) => {
         const existingNodes = getNodes().filter(
             n => n.internal.owner === `gatsby-source-flotiq`
         );
-        existingNodes.forEach(n => touchNode({nodeId: n.id, plugin: 'gatsby-source-flotiq'}));
+        existingNodes.forEach(n => touchNode(n));
         if (!existingNodes.length) {
             lastUpdate = undefined;
         }


### PR DESCRIPTION
1. Change touchNode params See https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v2-to-v3/#calling-touchnode-with-the-node-id
This update may fix the `FLOTIQ: Cannot read property 'type' of undefined` bug.

It should be checked how this change affects other code



This issue could be related with
https://github.com/flotiq/flotiq-blog/issues/36