### PR TITLE
fix graphQL for Any Type in relations

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -289,6 +289,8 @@ const createAditionalDef = (
 
 const createTypeDefs = (contentTypesDefinitions, schema, includeTypes) => {
     let typeDefs = [];
+    const names = contentTypesDefinitions.map(ctd => capitalize(ctd.name));
+    typeDefs.push(`union AllTypes = ${names.join(' | ')}`);
     contentTypesDefinitions.forEach(ctd => {
         let tmpDef = {
             name: capitalize(ctd.name),
@@ -344,6 +346,7 @@ const getType = (propertyConfig, required, property, ctdName, includeTypes) => {
         case 'datasource':
             if (
                 includeTypes
+                && propertyConfig.validation.relationContenttype !== ''
                 && includeTypes.indexOf(propertyConfig.validation.relationContenttype) === -1
                 && propertyConfig.validation.relationContenttype !== CTD_MEDIA
             ) {


### PR DESCRIPTION
This PR brings back the possibility of adding sections from different content types in one landing page.