### PR TITLE
Fix deleteNode

### DIFF
--- a/__tests__/default-usage.test.js
+++ b/__tests__/default-usage.test.js
@@ -152,7 +152,7 @@ describe('sourceNodes', () => {
             await sourceNodes(gatsbyFunctions, options)
 
             verifyAllWhenMocksCalled()
-            expect(actions.deleteNode).toBeCalledWith({node: expect.objectContaining({id: expect.stringContaining(CTD1_OBJECT1.id)})})
+            expect(actions.deleteNode).toBeCalledWith(expect.objectContaining({id: expect.stringContaining(CTD1_OBJECT1.id)}))
         });
 
         test('Updates only new data', async () => {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -81,7 +81,7 @@ exports.sourceNodes = async (gatsbyFunctions, options) => {
         if (lastUpdate && lastUpdate.updated_at) {
             removed = await getDeletedObjects(gatsbyFunctions, options, lastUpdate.updated_at, contentTypeDefsData, apiUrl, async (ctd, id) => {
                 let node = existingNodes.find(n => n.id === `${ctd.name}_${id}`);
-                return await deleteNode({node});
+                return await deleteNode(node);
             });
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "gatsby-source-flotiq",
-            "version": "5.2.0",
+            "version": "5.2.1",
             "license": "MIT",
             "dependencies": {
                 "gatsby-core-utils": "^4.3.1",


### PR DESCRIPTION
Bug
1. Start the Gatsby development server by running gatsby dev.
2. Create a post in Flotiq.
3. Trigger a refresh by calling http://localhost:8000/__refresh.
4. The post is successfully fetched and displayed.
5. Delete the post in Flotiq.
6. Trigger another refresh by calling http://localhost:8000/__refresh.
7. The post still appears in Gatsby